### PR TITLE
Typo in filename prevents building on Vercel.

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,1 +1,1 @@
-export { default as YouTube } from './Youtube.svelte';
+export { default as YouTube } from './YouTube.svelte';


### PR DESCRIPTION
./YouTube.svelte instead of ./Youtube.svelte